### PR TITLE
Fix Flask compatibility by pinning Werkzeug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
   ```bash
 pip install -r requirements.txt
 ```
+The `requirements.txt` file pins `Werkzeug` below version 3 to
+ensure compatibility with Flask.
 **Configuration**
 Create a `.env` file in the project root with the following variables:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.28.1
 gunicorn==20.1.0
 
 python-dotenv==1.0.1
+Werkzeug<3


### PR DESCRIPTION
## Summary
- pin Werkzeug version below 3 in `requirements.txt`
- note the Werkzeug pinning in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ec686a06c8320bf67b93475d949e1